### PR TITLE
fix(script): add correct behaviour to SIGINT

### DIFF
--- a/imcat
+++ b/imcat
@@ -23,6 +23,8 @@ cols=$(tput cols)
 rows=$(tput lines)
 rows=$(echo "$rows - $row_number" | bc)
 
+trap 'exit 1' INT
+
 for var in "$@"
 do
 {


### PR DESCRIPTION
trap command is added in the script to exit the script with error code
when SIGINT signal is passed to script via Ctrl-c.